### PR TITLE
Correct dealing with local component classes

### DIFF
--- a/src/can-be-asserted.js
+++ b/src/can-be-asserted.js
@@ -1,10 +1,12 @@
 import _ from 'lodash';
+import React from 'react';
 
 export default function canBeAsserted(vdom) {
     return _.all([].concat(vdom), node =>
-        node
+        React.isValidElement(node) ||
+        (node
         && typeof node === 'object'
         && typeof node.type === 'string'
-        && (!node.props || typeof node.props === 'object')
+        && (!node.props || typeof node.props === 'object'))
     );
 }

--- a/src/can-be-asserted.js
+++ b/src/can-be-asserted.js
@@ -2,11 +2,13 @@ import _ from 'lodash';
 import React from 'react';
 
 export default function canBeAsserted(vdom) {
+    function isCompatibleObject(node) {
+        return node
+            && typeof node === 'object'
+            && typeof node.type === 'string'
+            && (!node.props || typeof node.props === 'object');
+    }
+
     return _.all([].concat(vdom), node =>
-        React.isValidElement(node) ||
-        (node
-        && typeof node === 'object'
-        && typeof node.type === 'string'
-        && (!node.props || typeof node.props === 'object'))
-    );
+        React.isValidElement(node) || isCompatibleObject(node));
 }

--- a/test/can-be-asserted.spec.js
+++ b/test/can-be-asserted.spec.js
@@ -16,6 +16,18 @@ describe('The assertion predicate', function() {
         expect(predicate(<div><span></span></div>)).to.be.true;
     });
 
+    it('accepts a ReactElement from a local component class', function () {
+        let NonNativeComp = React.createClass({
+            render: function () {
+                return (<div></div>);
+            }
+        });
+
+        let comp = (<NonNativeComp />);
+
+        expect(predicate(comp)).to.be.true;
+    });
+
     it('accepts an object with a type field', function() {
         expect(predicate({type: 'div'})).to.be.true;
     });

--- a/test/chai-react-element.spec.js
+++ b/test/chai-react-element.spec.js
@@ -34,7 +34,6 @@ describe('ReactElement matcher', function() {
 		it('detects text in children array', function() {
 			expect(
 				() => {
-					debugger;
 					expect({type: 'div', props: {children: ['bar']}}).to.have.text('bar')
 				}).not.to.throw();
 		});


### PR DESCRIPTION
The matchers only worked for components that had native HTML elements as root.
Local component classes are now supported.